### PR TITLE
Set encoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
         <version.com.atlassian.confluence.data>5.3.4</version.com.atlassian.confluence.data>
         <version.com.atlassian.maven.plugins.amps>4.2.10</version.com.atlassian.maven.plugins.amps>
         <version.com.atlassian.plugins.testrunner>1.1.1</version.com.atlassian.plugins.testrunner>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <organization>


### PR DESCRIPTION
Without the encoding set the Java compiler will default to the platform encoding, which on a Mac results in the following warning:

```
[WARNING] Using platform encoding (MacRoman actually) to copy filtered resources, i.e. build is platform dependent!
```

Adding the UTF-8 encoding notation to pom.xml resolves this warning and potential issue.
